### PR TITLE
Pass 'lang' to all question forms

### DIFF
--- a/src/js/words/Babbel/given_english_question/index.ts
+++ b/src/js/words/Babbel/given_english_question/index.ts
@@ -59,7 +59,7 @@ export default class GivenEnglishQuestion implements Question<T, C> {
     }
 
     getQuestionFormComponent(): React.FunctionComponent<QuestionFormProps<T>> {
-        return Form(this.lang);
+        return Form;
     }
 
     getQuestionHeaderComponent(): React.FunctionComponent<QuestionHeaderProps<T, C, GivenEnglishQuestion>> {

--- a/src/js/words/CustomVocab/adjektiv/AdjektivGivenEnglish/index.ts
+++ b/src/js/words/CustomVocab/adjektiv/AdjektivGivenEnglish/index.ts
@@ -70,7 +70,7 @@ class AdjektivGivenEnglish implements Question<T, C> {
     }
 
     getQuestionFormComponent(): React.FunctionComponent<QuestionFormProps<T>> {
-        return Form(this.lang);
+        return Form;
     }
 
     getQuestionHeaderComponent(): React.FunctionComponent<QuestionHeaderProps<T, C, AdjektivGivenEnglish>> {

--- a/src/js/words/CustomVocab/types.ts
+++ b/src/js/words/CustomVocab/types.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {Omit, WithTranslation, WithTranslationProps} from "react-i18next";
 
 export type QuestionFormProps<AT> = {
+    lang: string;
     onAttempt: (attempt: AT | undefined) => void;
     onShowMessage: (msg: string) => void;
 } & WithTranslation

--- a/src/js/words/CustomVocab/udtryk/given_english_question/form.tsx
+++ b/src/js/words/CustomVocab/udtryk/given_english_question/form.tsx
@@ -3,7 +3,7 @@ import {useState} from 'react';
 import {T} from ".";
 import {QuestionFormProps} from "../../types";
 
-const Form = (vocabLang: string) => (props: QuestionFormProps<T>) => {
+const Form = (props: QuestionFormProps<T>) => {
     const [value, setValue] = useState<string>("");
 
     return (
@@ -28,7 +28,7 @@ const Form = (vocabLang: string) => (props: QuestionFormProps<T>) => {
                     autoCapitalize={'none'}
                     autoComplete={'off'}
                     autoCorrect={'off'}
-                    lang={vocabLang}
+                    lang={props.lang}
                 />
             </label>
         </div>

--- a/src/js/words/CustomVocab/udtryk/given_english_question/index.ts
+++ b/src/js/words/CustomVocab/udtryk/given_english_question/index.ts
@@ -56,7 +56,7 @@ class GivenEnglishQuestion implements Question<T, C> {
     }
 
     getQuestionFormComponent(): React.FunctionComponent<QuestionFormProps<T>> {
-        return Form(this.lang);
+        return Form;
     }
 
     getQuestionHeaderComponent(): React.FunctionComponent<QuestionHeaderProps<T, C, GivenEnglishQuestion>> {

--- a/src/js/words/CustomVocab/verbum/VerbumGivenEnglish/index.ts
+++ b/src/js/words/CustomVocab/verbum/VerbumGivenEnglish/index.ts
@@ -76,7 +76,7 @@ export default class VerbumGivenEnglish implements Question<T, C> {
         } as any)[this.lang]; // FIXME-any
 
         return (props: QuestionFormProps<T>) =>
-            Form(this.lang)({
+            Form({
                 ...props,
                 onAttempt: (attempt => {
                     if (attempt && !attempt.dansk.toLowerCase().startsWith(particlePrefix)) {

--- a/src/js/words/shared/standard_form_question2/form.tsx
+++ b/src/js/words/shared/standard_form_question2/form.tsx
@@ -67,6 +67,7 @@ class Form<T, C, Q extends Question<T, C>> extends React.Component<Props<T, C, Q
                     t={this.props.t}
                     i18n={this.props.i18n}
                     tReady={this.props.tReady}
+                    lang={this.props.question.lang}
                     onAttempt={(attempt: T) => this.setState({ attempt })}
                     onShowMessage={msg => this.showFadingMessage(msg)}
                 />


### PR DESCRIPTION
A much cleaner approach, and also doesn't nobble react component naming